### PR TITLE
Support for the raw format

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "typescript": "^2"
   },
   "devDependencies": {
+    "@types/node": "^6.0.62",
     "babel-preset-es2015": "^6.18.0",
     "live-server": "^1",
     "npm-run-all": "^3",

--- a/src/base.ts
+++ b/src/base.ts
@@ -69,7 +69,7 @@ export class BaseCrypto {
     static checkFormat(format: string, type?: string) {
         switch (format.toLowerCase()) {
             case "raw":
-                if (type && type.toLowerCase() !== "secret")
+                if (type && type.toLowerCase() !== "secret" && type && type.toLowerCase() !== "public")
                     throw new CryptoKeyError(CryptoKeyError.WRONG_FORMAT, type, "raw");
                 break;
             case "pkcs8":

--- a/src/ec/crypto.ts
+++ b/src/ec/crypto.ts
@@ -65,8 +65,6 @@ export class Ec extends BaseCrypto {
         return new Promise((resolve, reject) => {
             this.checkKeyGenParams(algorithm);
             this.checkFormat(format);
-            if (format.toLowerCase() === "raw")
-                throw new CryptoKeyError(CryptoKeyError.ALLOWED_FORMAT, format, "'JsonWebKey', 'pkcs8' or 'spki'");
             this.checkKeyGenUsages(keyUsages);
             resolve(undefined);
         });

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -118,9 +118,15 @@ describe("Webcrypto", () => {
         context("checkFormat", () => {
             var checkFormat = BaseCrypto.checkFormat;
 
-            ["public", "private"].forEach(type =>
+            ["private"].forEach(type =>
                 it(`raw for ${type}`, () => {
-                    assert.throws(() => checkFormat("rAw", type), Error);
+                    assert.throws(() => checkFormat("raw", type), Error);
+                })
+            );
+
+            ["private"].forEach(type =>
+                it(`jwk for ${type}`, () => {
+                    assert.throws(() => checkFormat("raw", type), Error);
                 })
             );
 

--- a/test/ec.js
+++ b/test/ec.js
@@ -358,7 +358,86 @@ describe("Subtle", function () {
                 exportKey("jwk", key, done, true);
             });
 
-        }); // import/export
+        }); // import/export ECDSA
+			
+        context("import/export ECDH", function () {
+
+            it("import raw", function (done) {
+                var alg = {
+                    name: "ecdh",
+                    namedCurve: "p-256"
+                }
+                importKey("raw", {}, alg, ["deriveKey", "deriveBits"], done, false);
+            });
+
+            it("import jwk", function (done) {
+                var alg = {
+                    name: "ecdh",
+                    namedCurve: "p-256"
+                }
+                importKey("jwk", {}, alg, ["deriveKey", "deriveBits"], done, false);
+            });
+
+            it("import spki", function (done) {
+                var alg = {
+                    name: "ecdh",
+                    namedCurve: "p-256"
+                }
+                importKey("spki", new Uint8Array(5), alg, ["deriveKey", "deriveBits"], done, false);
+            });
+
+            it("import wrong alg namedCurver", function (done) {
+                var alg = {
+                    name: "ecdh",
+                    namedCurve: "wrong"
+                }
+                importKey("jwk", {}, alg, ["deriveKey", "deriveBits"], done, true);
+            });
+
+            it("import", function (done) {
+                var alg = {
+                    name: "ecdh",
+                    namedCurve: "p-256"
+                }
+                importKey("jwk", {}, alg, ["deriveKey", "deriveBits"], done, false);
+            });
+
+            // export
+
+            it("export raw", function (done) {
+                var key = {
+                    algorithm: {
+                        name: "ecdh"
+                    },
+                    type: "public",
+                    extractable: true
+                };
+                exportKey("raw", key, done, false);
+            });
+
+            it("export", function (done) {
+                var key = {
+                    algorithm: {
+                        name: "ecdh"
+                    },
+                    type: "public",
+                    extractable: true
+                };
+                exportKey("jwk", key, done, false);
+            });
+
+            it("export not extractable", function (done) {
+                var key = {
+                    algorithm: {
+                        name: "ecdh"
+                    },
+                    type: "public",
+                    extractable: false
+                };
+                exportKey("jwk", key, done, true);
+            });
+
+        }); // import/export ECDSA			
 
     });
 

--- a/test/ec.js
+++ b/test/ec.js
@@ -281,7 +281,15 @@ describe("Subtle", function () {
 
         }); // deriveKey
 
-        context("import/export", function () {
+        context("import/export ECDSA", function () {
+
+            it("import raw", function (done) {
+                var alg = {
+                    name: "ecdsa",
+                    namedCurve: "p-256"
+                }
+                importKey("raw", {}, alg, ["sign"], done, false);
+            });
 
             it("import jwk", function (done) {
                 var alg = {
@@ -316,6 +324,17 @@ describe("Subtle", function () {
             });
 
             // export
+
+            it("export raw", function (done) {
+                var key = {
+                    algorithm: {
+                        name: "ecdsa"
+                    },
+                    type: "public",
+                    extractable: true
+                };
+                exportKey("raw", key, done, false);
+            });
 
             it("export", function (done) {
                 var key = {


### PR DESCRIPTION
This prepares the raw format support for **node-webcrypto-ossl**, as discussed under PeculiarVentures/node-webcrypto-ossl/issues/89

Most comments can be found in the commit e36c1ee

I did not test, if these changes have any influence on [node-webcrypto-ossl](https://github.com/PeculiarVentures/node-webcrypto-ossl), [node-webcrypto-p11](https://github.com/PeculiarVentures/node-webcrypto-p11), and [webcrypto-liner](https://github.com/PeculiarVentures/webcrypto-liner).