### PR TITLE
fix: RSA-PSS salt length

### DIFF
--- a/src/rsa/pss.ts
+++ b/src/rsa/pss.ts
@@ -15,8 +15,8 @@ export abstract class RsaPssProvider extends RsaProvider {
     if (typeof algorithm.saltLength !== "number") {
       throw new TypeError("saltLength: Is not a Number");
     }
-    if (algorithm.saltLength < 1) {
-      throw new RangeError("saltLength: Must be more than 0");
+    if (algorithm.saltLength < 0) {
+      throw new RangeError("saltLength: Must be positive number");
     }
   }
 

--- a/test/rsa.ts
+++ b/test/rsa.ts
@@ -152,9 +152,9 @@ context("RSA", () => {
         }, TypeError);
       });
 
-      it("error if `saltLength` is less than 1", () => {
+      it("error if `saltLength` is less than 0", () => {
         assert.throws(() => {
-          provider.checkAlgorithmParams({ saltLength: 0 } as any);
+          provider.checkAlgorithmParams({ saltLength: -1 } as any);
         }, RangeError);
       });
 


### PR DESCRIPTION
According to the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/RsaPssParams) and RFC 3447 a typical `saltLength` in the `RsaPssParams` is `0`.  The current validation [here](https://github.com/PeculiarVentures/webcrypto-core/blob/master/src/rsa/pss.ts#L18) prohibits a `saltLength` smaller than `1`.

This PR addresses this issue and checks if the `saltLength` is below `0` instead of `1`.