### PR TITLE
Added NO-HASH option for ECDSA, for cases the data is already hashed

### DIFF
--- a/src/ec/ecdsa.ts
+++ b/src/ec/ecdsa.ts
@@ -5,7 +5,7 @@ export abstract class EcdsaProvider extends EllipticProvider {
 
   public readonly name: string = "ECDSA";
 
-  public readonly hashAlgorithms = ["SHA-1", "SHA-256", "SHA-384", "SHA-512"];
+  public readonly hashAlgorithms = ["SHA-1", "SHA-256", "SHA-384", "SHA-512", "NO-HASH"];
 
   public usages: ProviderKeyUsages = {
     privateKey: ["sign"],


### PR DESCRIPTION
We ran into a use case where the data to be signed via ECDSA is already hashed, and should not be hashed again. I added the option to do with the hash algorithm `"NO-HASH"`.
This is in conjuncture with a pull request to node-webcrypto-p11.